### PR TITLE
Speed up pages.yml's dependency install

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -47,13 +47,33 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y libuv1-dev libgit2-dev libcurl4-openssl-dev libssl-dev libxml2-dev
 
-      # The repo-root .Rprofile adds a2-ai.r-universe.dev to options(repos=)
-      # automatically once R starts here, so pak resolves pyro (no CRAN
-      # release for it) the same way local dev does.
-      - name: Install deckifyr and pkgdown
+      # Identical to R-CMD-check.yaml/test-coverage.yaml/release.yaml's own
+      # step -- keep all four in sync if DESCRIPTION's
+      # Additional_repositories ever changes. See CLAUDE.md's architecture
+      # notes on why the repo-root .Rprofile alone isn't trusted to cover
+      # every job/action combination here.
+      - name: Add Additional_repositories from DESCRIPTION (pyro via a2-ai.r-universe.dev)
         run: |
-          Rscript -e 'install.packages("pak", repos = "https://r-lib.github.io/p/pak/stable/")'
-          Rscript -e 'pak::pkg_install(c("local::.", "pkgdown"), dependencies = TRUE)'
+          raw <- read.dcf("DESCRIPTION", fields = "Additional_repositories")[1, 1]
+          if (!is.na(raw) && nzchar(raw)) {
+            repos <- trimws(strsplit(raw, ",")[[1]])
+            cat(sprintf("options(repos = c(getOption('repos'), %s))\n", deparse(repos)),
+                file = path.expand("~/.Rprofile"), append = TRUE)
+          }
+        shell: Rscript {0}
+
+      # r-lib's own canonical pkgdown.yaml example workflow
+      # (r-lib/actions/examples/pkgdown.yaml) uses exactly this action/needs
+      # combination. Previously this step called `pak::pkg_install(...,
+      # dependencies = TRUE)` directly -- that recursively pulls every
+      # Suggests of every transitive dependency (not just deckifyr's own)
+      # and, unlike this action, has no cross-run cache, which made a cold
+      # run take 15+ minutes for what R-CMD-check.yaml's own dependency
+      # install (same action, same repo) finishes in under a minute.
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::pkgdown, local::.
+          needs: website
 
       - name: Build pkgdown site
         run: Rscript -e 'pkgdown::build_site(new_process = FALSE, install = FALSE)'


### PR DESCRIPTION
## Summary
- The `Deploy Docs` run triggered by #5's merge succeeded, but its manual `pak::pkg_install(c("local::.", "pkgdown"), dependencies = TRUE)` step took ~13 minutes (00:40:36 → 00:53:33) versus 13 seconds for the actual `pkgdown::build_site()` call.
- `dependencies = TRUE` recursively installs every `Suggests` of every transitive dependency, not just deckifyr's own — a far bigger graph than a pkgdown build needs. The step also had no cross-run cache, unlike `R-CMD-check.yaml`/`test-coverage.yaml`/`release.yaml`, which all use `r-lib/actions/setup-r-dependencies@v2` and finish dependency install in well under a minute via its `actions/cache`-backed R library cache.
- Swaps `pages.yml`'s install step for that same action (`needs: website`, `extra-packages: any::pkgdown, local::.`), matching r-lib's own canonical `pkgdown.yaml` example workflow, plus the same `Additional_repositories` step the other three workflows already use to resolve `pyro`.

## Test plan
- [x] Confirmed via `gh api .../jobs` that the old step's 13-minute duration was real, not a fluke — `Build pkgdown site` itself only took 13s.
- [ ] Next push to `main` touching a `pages.yml`-watched path is the real test of the swapped-in action; expect a first cold run to still pay for cache population, then near-instant subsequent runs (same pattern already observed for `R-CMD-check.yaml`/`release.yaml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)