### PR TITLE
Configure Dependabot for web and Python

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+updates:
+  # pyproject.toml and uv.lock live at the repository root. The Python
+  # package source is under inst/python, but Dependabot follows manifests.
+  - package-ecosystem: "uv"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+
+  # The frontend is a separate npm project within the R package repository.
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## Summary

- configure Dependabot's `uv` ecosystem at the repository root for `pyproject.toml` and `uv.lock`
- configure Dependabot's `npm` ecosystem at `/web` for the frontend manifest and lockfile
- document why the Python manifest directory differs from the bundled source location under `inst/python`

## Why

The R package bundles both a Python engine and statically built web assets. Explicit ecosystem and manifest-directory entries ensure Dependabot version updates—and security-update PR routing when enabled—cover both non-R dependency trees.

GitHub's live dependency graph was also checked before this change and already recognizes both ecosystems: 35 Python packages and 210 npm packages, with no currently open Dependabot alerts.

## Validation

- parsed `.github/dependabot.yml` as YAML and asserted the expected `uv` `/` and `npm` `/web` entries
- ran `git diff --check`
- verified Dependabot alerts are enabled through the GitHub API
- verified the generated dependency graph includes both PyPI and npm packages

## Note

Automatic Dependabot security-update pull requests are currently disabled in repository settings. Vulnerability alerts remain enabled and operate independently.
