### PR TITLE
Scope Dependabot update pull requests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,8 +8,16 @@ updates:
     schedule:
       interval: "weekly"
 
-  # The frontend is a separate npm project within the R package repository.
+  # The frontend is a local-only interface whose built assets are committed.
+  # Keep vulnerability alerts, but do not open routine version-update PRs.
   - package-ecosystem: "npm"
     directory: "/web"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 0
+
+  # Workflow action updates are exercised directly by the repository's CI.
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
## What changed

- disable routine Dependabot version-update PRs for the local-only npm frontend
- keep weekly Python updates through the root `uv` project
- add weekly updates for GitHub Actions used by repository workflows

## Why

The existing pull-request workflows run R and Python checks for npm-only updates, but do not install, test, or rebuild the frontend. This avoids spending CI resources on checks that do not exercise those changes while retaining vulnerability alerts as a separate repository security feature.

GitHub Actions updates remain enabled because the changed action versions are exercised directly when the pull-request workflows run.

## Validation

- parsed `.github/dependabot.yml` as YAML
- asserted the `uv` `/`, `npm` `/web`, and `github-actions` `/` ecosystem mappings
- asserted `open-pull-requests-limit: 0` for npm
- ran `git diff --check`
